### PR TITLE
debian package: change dependency to java8-runtime-headless

### DIFF
--- a/lsq-debian-cli/src/deb/control/control
+++ b/lsq-debian-cli/src/deb/control/control
@@ -3,7 +3,7 @@ Version: [[version]]
 Section: web
 Priority: optional
 Architecture: all
-Depends: openjdk-8-jre-headless
+Depends: java8-runtime-headless
 Maintainer: Claus Stadler <cstadler@informatik.uni-leipzig.de>
 Description: Sparqlify Command Line Interfaces
 Distribution: ldstack-nightly


### PR DESCRIPTION
Instead of depending on a specific java runtime package (openjdk-8-jre-headless) the debian package should depend on the java8-runtime-headless metapackage.
This allows the use of other jdk packages such as adoptopenjdk.
It also seems to be in line with the debian packaging guidelines found here: https://www.debian.org/doc/packaging-manuals/java-policy/ch02.html#policy-programs
"Programs must depend on the needed runtime environment (default-jre or default-jre-headless if need a GUI or not, and java<N>-runtime or java<N>-runtime-headless as provided by alternative Java environments)."
This also makes it possible to install the package on newer os versions (such as debian buster or ubuntu 20.04) which no longer ship openjdk-8-jre-headless.

It might also be possible to use a different dependency string (such as `default-jre-headless (>= 2:1.8)`), but java8-runtime-headless seems to be the cleanest solution.