### PR TITLE
lsq-debian-cli: Compatibility with Debian 11 (Bullseye)

### DIFF
--- a/lsq-debian-cli/src/deb/control/control
+++ b/lsq-debian-cli/src/deb/control/control
@@ -3,7 +3,7 @@ Version: [[version]]
 Section: web
 Priority: optional
 Architecture: all
-Depends: openjdk-8-jre-headless
+Recommends: default-jre-headless
 Maintainer: Claus Stadler <cstadler@informatik.uni-leipzig.de>
 Description: Sparqlify Command Line Interfaces
 Distribution: ldstack-nightly


### PR DESCRIPTION
The package depends on openjdk-8-jre-headless, which is no longer available in Debian's upcoming stable release.
As the package seems to works fine with OpenJDK 11 and 16, I changed to dependency name to default-jre-headless, which always targets the latest OpenJDK LTS release included with Debian.
I also changed Depends to Recommends. When not using the JDK provided by Debian (like I do), then you shouldn't be forced to install it, but apt would still install the default JDK with LSQ if you don't tell it to do otherwise (--no-install-recommends).