### PR TITLE
Add Dockerfile and github workflow to build/publish docker image

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -1,0 +1,53 @@
+name: Publish Docker image
+# To AKSW GitHub Container Registry
+# https://github.com/orgs/AKSW/packages
+on:
+  workflow_dispatch:
+  push:
+    # Publish `develop` as Docker `latest` image.
+    branches:
+      - develop
+    # Publish `v1.2.3` tags as releases.
+    tags:
+      - v*
+  release:
+    types:
+      - created
+
+env:
+  IMAGE_NAME: lsq
+
+jobs:
+  build-publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build image
+        run: docker build . --file Dockerfile --tag $IMAGE_NAME
+
+      - name: Log into GitHub Container Registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login https://ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Push image to GitHub Container Registry
+        run: |
+          IMAGE_ID=ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME
+
+          # Change all uppercase to lowercase
+          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
+
+          # Strip git ref prefix from version
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+
+          # Strip "v" prefix from tag name
+          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+
+          # Use Docker `latest` tag convention
+          [ "$VERSION" == "develop" ] && VERSION=latest
+
+          echo IMAGE_ID=$IMAGE_ID
+          echo VERSION=$VERSION
+
+          docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
+          docker push $IMAGE_ID:$VERSION

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+FROM maven:3-jdk-11 as build
+
+COPY . .
+RUN mvn -Pdist,standalone clean install
+
+
+# Final running image
+FROM openjdk:11-jre-slim
+
+# Import the lsq-cli jar from the build step
+COPY --from=build lsq-cli/target/lsq-cli-*-jar-with-dependencies.jar /app/lsq-cli.jar
+
+RUN apt-get update && \
+    apt-get install -y wget
+
+# # Install Spark for standalone context in /opt
+# ENV APACHE_SPARK_VERSION=3.2.0
+# ENV HADOOP_VERSION=3.2
+# ENV SPARK_HOME=/opt/spark
+# ENV SPARK_OPTS="--driver-java-options=-Xms1024M --driver-java-options=-Xmx2048M --driver-java-options=-Dlog4j.logLevel=info"
+# RUN wget -q -O spark.tgz https://archive.apache.org/dist/spark/spark-${APACHE_SPARK_VERSION}/spark-${APACHE_SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz && \
+#     tar xzf spark.tgz -C /opt && \
+#     rm "spark.tgz" && \
+#     ln -s "/opt/spark-${APACHE_SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}" $SPARK_HOME
+
+
+# Using /data as working directory that will be shared with host for input/output files
+WORKDIR /data
+VOLUME [ "/data" ]
+
+ENTRYPOINT ["java","-jar","/app/lsq-cli.jar"]
+CMD ["-h"]
+
+# Usage:
+# docker run -it -v $(pwd):/data ghcr.io/aksw/lsq rx rdfize --endpoint=http://dbpedia.org/sparql virtuoso.dbpedia.log 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,19 @@ lsq rx benchmark run -c benchmark.run.ttl *.log.trig
 The `-o` option causes the settings to be written to the console. Omit `-o` to have LSQ auto-generate files.
 
 
-![LSQ Process Overview](lsq-docs/lsq2-overview.svg "")
+#### Run with Docker
+
+Run example running LSQ to RDFize SPARQL logs, input and output files in the current working directory (replace `$(pwd)` by `${PWD}` for Windows PowerShell):
+
+```bash
+docker run -it -v $(pwd):/data ghcr.io/aksw/lsq rx rdfize --endpoint=http://dbpedia.org/sparql virtuoso.dbpedia.log 
+```
+
+Build the Docker image from the source code:
+
+```bash
+docker build -t ghcr.io/aksw/lsq .
+```
 
 
 ## License


### PR DESCRIPTION

I added a simple Dockerfile, and a GitHub Actions workflow to automatically build and publish the image to AKSW container registry on GitHub (works well, directly integrated in GitHub, and no pull requests limitation for non logged in users, which starts to be a major issue when using DockerHub)

Note it's a "multistage" build so it only takes the `lsq-cli` jar with dep file to the final image


The GitHub Action workflow will publish a new image when:
* a new `latest` image to every push to `develop` (you can change it to master if you prefer, but you'll need to merge the Dockerfile in the `master` branch first)
* or when you create a new tag/release (tag starting with v, e.g. `v0.0.1`)


For Spark I am not sure how you plan to use it. I guess by connecting to an existing Spark cluster, but I added some commented lines to setup Spark in the docker image (already tested, *should* work), so you should be able to also use Spark directly as standalone within the image


Ideally in the future you should be able to pass the Spark cluster URL as an environment variable

I also added basic usage documentation in the `README.md`