### PR TITLE
Replace broken maven repo of SPIN API with GitHub repo

### DIFF
--- a/lsq-cli/src/main/java/org/aksw/simba/lsq/cli/main/MainCliLsq.java
+++ b/lsq-cli/src/main/java/org/aksw/simba/lsq/cli/main/MainCliLsq.java
@@ -92,7 +92,7 @@ import org.apache.jena.vocabulary.RDFS;
 import org.apache.jena.vocabulary.XSD;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.topbraid.spin.vocabulary.SP;
+import org.spinrdf.vocabulary.SP;
 
 import com.google.common.io.BaseEncoding;
 

--- a/lsq-core/pom.xml
+++ b/lsq-core/pom.xml
@@ -56,9 +56,14 @@
 		</dependency>
 
 
-		<dependency>
+		<!-- <dependency>
 			<groupId>org.topbraid</groupId>
 			<artifactId>spin</artifactId>
+		</dependency> -->
+		<dependency>
+			<groupId>com.github.spinrdf</groupId>
+			<artifactId>spinrdf</artifactId>
+			<version>master-SNAPSHOT</version>
 		</dependency>
 
 		<!-- <dependency> <groupId>org.topbraid</groupId> <artifactId>shacl</artifactId> 

--- a/lsq-core/src/main/java/org/aksw/simba/lsq/core/util/SpinUtils.java
+++ b/lsq-core/src/main/java/org/aksw/simba/lsq/core/util/SpinUtils.java
@@ -4,17 +4,17 @@ import org.apache.jena.query.Query;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.Resource;
-import org.topbraid.spin.arq.ARQ2SPIN;
+import org.spinrdf.arq.ARQ2SPIN;
 
 public class SpinUtils {
-    public static org.topbraid.spin.model.Query createSpinModel(
+    public static org.spinrdf.model.Query createSpinModel(
             Query query,
             Model tgtModel
             ) {
 
         return createSpinModel(query, tgtModel.createResource());
     }
-    public static org.topbraid.spin.model.Query createSpinModel(
+    public static org.spinrdf.model.Query createSpinModel(
             Query query,
             Resource spinRes
 //            BiFunction<? super Resource, String, String> lsqResToIri
@@ -31,7 +31,7 @@ public class SpinUtils {
             spinModel = ModelFactory.createDefaultModel();
         }
         ARQ2SPIN arq2spin = new ARQ2SPIN(spinModel);
-        org.topbraid.spin.model.Query tmpSpinRes = arq2spin.createQuery(query, spinRes == null ? null : spinRes.getURI());
+        org.spinrdf.model.Query tmpSpinRes = arq2spin.createQuery(query, spinRes == null ? null : spinRes.getURI());
 
         // ... and rename the blank node of the query
         // ResourceUtils.renameResource(tmpSpinRes, spinRes.getURI());

--- a/lsq-enrichers/src/main/java/org/aksw/simba/lsq/enricher/benchmark/core/LsqBenchmarkProcessor.java
+++ b/lsq-enrichers/src/main/java/org/aksw/simba/lsq/enricher/benchmark/core/LsqBenchmarkProcessor.java
@@ -90,7 +90,7 @@ import org.apache.jena.update.UpdateRequest;
 import org.apache.jena.util.ResourceUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.topbraid.spin.model.TriplePattern;
+import org.spinrdf.model.TriplePattern;
 
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.FlowableTransformer;

--- a/lsq-enrichers/src/main/java/org/aksw/simba/lsq/enricher/core/LsqEnrichments.java
+++ b/lsq-enrichers/src/main/java/org/aksw/simba/lsq/enricher/core/LsqEnrichments.java
@@ -56,8 +56,8 @@ import org.apache.jena.vocabulary.RDF;
 import org.apache.jena.vocabulary.RDFS;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.topbraid.spin.model.TriplePattern;
-import org.topbraid.spin.vocabulary.SP;
+import org.spinrdf.model.TriplePattern;
+import org.spinrdf.vocabulary.SP;
 
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Multimap;
@@ -253,9 +253,9 @@ public class LsqEnrichments {
             Model spinModel = bgpInfo.getModel();
 
             // Extend the spin model with BGPs
-            Multimap<Resource, org.topbraid.spin.model.Triple> bgpToTps = SpinAccessUtils.indexBasicPatterns2(spinModel); //queryRes);
+            Multimap<Resource, org.spinrdf.model.Triple> bgpToTps = SpinAccessUtils.indexBasicPatterns2(spinModel); //queryRes);
 
-            for(Entry<Resource, Collection<org.topbraid.spin.model.Triple>> e : bgpToTps.asMap().entrySet()) {
+            for(Entry<Resource, Collection<org.spinrdf.model.Triple>> e : bgpToTps.asMap().entrySet()) {
 
 
                 // Map each resource to the corresponding jena element
@@ -282,7 +282,7 @@ public class LsqEnrichments {
     //            }
 
                 List<LsqTriplePattern> bgpTps = bgpCtxRes.getTriplePatterns();
-                for(org.topbraid.spin.model.Triple tp : e.getValue()) {
+                for(org.spinrdf.model.Triple tp : e.getValue()) {
                     // System.err.println("TP:" + tp);
 
                     bgpTps.add(tp.as(LsqTriplePattern.class));
@@ -794,9 +794,9 @@ public class LsqEnrichments {
 
 //        RDFDataMgr.write(System.err, spinBgp.getModel(), RDFFormat.TURTLE_BLOCKS);
 
-        Iterable<? extends org.topbraid.spin.model.Triple> spinTriples = spinBgp.getTriplePatterns();
+        Iterable<? extends org.spinrdf.model.Triple> spinTriples = spinBgp.getTriplePatterns();
 
-        for (org.topbraid.spin.model.Triple st : spinTriples) {
+        for (org.spinrdf.model.Triple st : spinTriples) {
             Triple t = SpinCoreUtils.toJenaTriple(st);
             // Get the triple's nodes
             Node s = t.getSubject();

--- a/lsq-enrichers/src/main/java/org/aksw/simba/lsq/enricher/core/QueryStatistics2.java
+++ b/lsq-enrichers/src/main/java/org/aksw/simba/lsq/enricher/core/QueryStatistics2.java
@@ -140,15 +140,15 @@ public class QueryStatistics2 {
      * @param triples
      * @return
      */
-    public static Map<org.topbraid.spin.model.Triple, Long> fetchRestrictedResultSetRowCount(QueryExecutionFactory qef, Collection<? extends org.topbraid.spin.model.Triple> triples) {
-        Map<org.topbraid.spin.model.Triple, Element> map = MapUtils.index(triples, t -> ElementUtils.createElement(SpinCoreUtils.toJenaTriple(t)));
+    public static Map<org.spinrdf.model.Triple, Long> fetchRestrictedResultSetRowCount(QueryExecutionFactory qef, Collection<? extends org.spinrdf.model.Triple> triples) {
+        Map<org.spinrdf.model.Triple, Element> map = MapUtils.index(triples, t -> ElementUtils.createElement(SpinCoreUtils.toJenaTriple(t)));
 
-        Map<org.topbraid.spin.model.Triple, Long> result = fetchRestrictedResultSetRowCount(qef, map);
+        Map<org.spinrdf.model.Triple, Long> result = fetchRestrictedResultSetRowCount(qef, map);
         return result;
     }
 
 
-    public static Map<Var, Long> fetchCountVarJoin(QueryExecutionFactory qef, Collection<org.topbraid.spin.model.Triple> triples) {
+    public static Map<Var, Long> fetchCountVarJoin(QueryExecutionFactory qef, Collection<org.spinrdf.model.Triple> triples) {
         Set<Element> map = triples.stream()
                 .map(t -> ElementUtils.createElement(SpinCoreUtils.toJenaTriple(t)))
                 .collect(Collectors.toSet());

--- a/lsq-enrichers/src/main/java/org/aksw/simba/lsq/enricher/core/SpinAccessUtils.java
+++ b/lsq-enrichers/src/main/java/org/aksw/simba/lsq/enricher/core/SpinAccessUtils.java
@@ -13,8 +13,8 @@ import org.apache.jena.rdf.model.RDFList;
 import org.apache.jena.rdf.model.RDFNode;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.util.ResourceUtils;
-import org.topbraid.spin.model.TriplePattern;
-import org.topbraid.spin.vocabulary.SP;
+import org.spinrdf.model.TriplePattern;
+import org.spinrdf.vocabulary.SP;
 
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
@@ -44,7 +44,7 @@ public class SpinAccessUtils {
      );
 
 
-    public static Set<RDFNode> listRDFNodes(org.topbraid.spin.model.Triple triple) {
+    public static Set<RDFNode> listRDFNodes(org.spinrdf.model.Triple triple) {
         Set<RDFNode> result = new LinkedHashSet<>();
         result.add(triple.getSubject());
         result.add(triple.getPredicate());
@@ -53,14 +53,14 @@ public class SpinAccessUtils {
     }
 
 
-    public static Multimap<Resource, org.topbraid.spin.model.Triple> indexBasicPatterns2(Resource r) {
+    public static Multimap<Resource, org.spinrdf.model.Triple> indexBasicPatterns2(Resource r) {
         Model spinModel = ResourceUtils.reachableClosure(r);
-        Multimap<Resource, org.topbraid.spin.model.Triple> result = indexBasicPatterns2(spinModel);
+        Multimap<Resource, org.spinrdf.model.Triple> result = indexBasicPatterns2(spinModel);
         return result;
     }
 
-    public static Multimap<Resource, org.topbraid.spin.model.Triple> indexBasicPatterns2(Model spinModel) {
-        Multimap<Resource, org.topbraid.spin.model.Triple> result = ArrayListMultimap.create();
+    public static Multimap<Resource, org.spinrdf.model.Triple> indexBasicPatterns2(Model spinModel) {
+        Multimap<Resource, org.spinrdf.model.Triple> result = ArrayListMultimap.create();
 
         {
             Set<Resource> ress = ConceptModelUtils

--- a/lsq-legacy/src/main/java/org/aksw/simba/lsq/TestLsqQueryJoinType.java
+++ b/lsq-legacy/src/main/java/org/aksw/simba/lsq/TestLsqQueryJoinType.java
@@ -10,7 +10,7 @@ import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.riot.RDFDataMgr;
 import org.apache.jena.riot.RDFFormat;
-import org.topbraid.spin.arq.ARQ2SPIN;
+import org.spinrdf.arq.ARQ2SPIN;
 
 public class TestLsqQueryJoinType {
     //@Test

--- a/lsq-legacy/src/main/java/org/aksw/simba/lsq/TestLsqSelectivity.java
+++ b/lsq-legacy/src/main/java/org/aksw/simba/lsq/TestLsqSelectivity.java
@@ -24,9 +24,9 @@ import org.apache.jena.riot.RDFDataMgr;
 import org.apache.jena.riot.RDFFormat;
 import org.apache.jena.sparql.core.Var;
 import org.junit.Test;
-import org.topbraid.spin.arq.ARQ2SPIN;
-import org.topbraid.spin.model.Query;
-import org.topbraid.spin.model.Triple;
+import org.spinrdf.arq.ARQ2SPIN;
+import org.spinrdf.model.Query;
+import org.spinrdf.model.Triple;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.Multimap;

--- a/lsq-legacy/src/main/java/org/aksw/simba/lsq/util/SpinUtilsOld.java
+++ b/lsq-legacy/src/main/java/org/aksw/simba/lsq/util/SpinUtilsOld.java
@@ -35,8 +35,8 @@ import org.apache.jena.sparql.expr.aggregate.AggCount;
 import org.apache.jena.sparql.util.FmtUtils;
 import org.apache.jena.util.ResourceUtils;
 import org.apache.jena.vocabulary.RDFS;
-import org.topbraid.spin.model.TriplePattern;
-import org.topbraid.spin.vocabulary.SP;
+import org.spinrdf.model.TriplePattern;
+import org.spinrdf.vocabulary.SP;
 
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.BiMap;

--- a/lsq-model/pom.xml
+++ b/lsq-model/pom.xml
@@ -25,9 +25,14 @@
 			<artifactId>lsq-vocab-jena</artifactId>
 		</dependency>
 
-		<dependency>
+		<!-- <dependency>
 			<groupId>org.topbraid</groupId>
 			<artifactId>spin</artifactId>
+		</dependency> -->
+		<dependency>
+			<groupId>com.github.spinrdf</groupId>
+			<artifactId>spinrdf</artifactId>
+			<version>master-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>

--- a/lsq-model/src/main/java/org/aksw/simba/lsq/model/JoinVertex.java
+++ b/lsq-model/src/main/java/org/aksw/simba/lsq/model/JoinVertex.java
@@ -3,7 +3,7 @@ package org.aksw.simba.lsq.model;
 import org.aksw.jenax.annotation.reprogen.Iri;
 import org.aksw.simba.lsq.vocab.LSQ;
 import org.apache.jena.rdf.model.Resource;
-import org.topbraid.spin.model.Variable;
+import org.spinrdf.model.Variable;
 
 public interface JoinVertex
 	extends Resource

--- a/lsq-model/src/main/java/org/aksw/simba/lsq/model/util/SpinCoreUtils.java
+++ b/lsq-model/src/main/java/org/aksw/simba/lsq/model/util/SpinCoreUtils.java
@@ -10,8 +10,8 @@ import org.apache.jena.rdf.model.Property;
 import org.apache.jena.rdf.model.RDFNode;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.sparql.core.Var;
-import org.topbraid.spin.model.Variable;
-import org.topbraid.spin.vocabulary.SP;
+import org.spinrdf.model.Variable;
+import org.spinrdf.vocabulary.SP;
 
 public class SpinCoreUtils {
 
@@ -89,7 +89,7 @@ public class SpinCoreUtils {
         return result;
     }
 
-    public static Triple toJenaTriple(org.topbraid.spin.model.Triple t) {
+    public static Triple toJenaTriple(org.spinrdf.model.Triple t) {
         Triple result = new Triple(toNode(t.getSubject()), toNode(t.getPredicate()), toNode(t.getObject()));
         return result;
     }

--- a/lsq-model/src/main/java/org/aksw/simba/lsq/spinx/model/Bgp.java
+++ b/lsq-model/src/main/java/org/aksw/simba/lsq/spinx/model/Bgp.java
@@ -14,7 +14,7 @@ import org.aksw.simba.lsq.vocab.LSQ;
 import org.apache.jena.graph.Node;
 import org.apache.jena.rdf.model.RDFNode;
 import org.apache.jena.sparql.core.BasicPattern;
-import org.topbraid.spin.model.Triple;
+import org.spinrdf.model.Triple;
 
 
 @ResourceView

--- a/lsq-model/src/main/java/org/aksw/simba/lsq/spinx/model/BgpNode.java
+++ b/lsq-model/src/main/java/org/aksw/simba/lsq/spinx/model/BgpNode.java
@@ -16,7 +16,7 @@ import org.apache.jena.graph.Node;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.RDFNode;
 import org.apache.jena.rdf.model.Resource;
-import org.topbraid.spin.vocabulary.SP;
+import org.spinrdf.vocabulary.SP;
 
 import com.google.common.collect.Iterables;
 import com.google.common.hash.HashCode;

--- a/lsq-model/src/main/java/org/aksw/simba/lsq/spinx/model/LsqTriplePattern.java
+++ b/lsq-model/src/main/java/org/aksw/simba/lsq/spinx/model/LsqTriplePattern.java
@@ -13,7 +13,7 @@ import org.aksw.simba.lsq.vocab.LSQ;
 import org.apache.jena.enhanced.EnhGraph;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.Triple;
-import org.topbraid.spin.model.impl.TriplePatternImpl;
+import org.spinrdf.model.impl.TriplePatternImpl;
 
 import com.google.common.hash.HashCode;
 

--- a/lsq-model/src/main/java/org/aksw/simba/lsq/spinx/model/SpinVarOrLiteral.java
+++ b/lsq-model/src/main/java/org/aksw/simba/lsq/spinx/model/SpinVarOrLiteral.java
@@ -5,7 +5,7 @@ import org.aksw.jenax.annotation.reprogen.IriNs;
 import org.aksw.jenax.annotation.reprogen.ResourceView;
 import org.apache.jena.rdf.model.RDFNode;
 import org.apache.jena.rdf.model.Resource;
-import org.topbraid.spin.vocabulary.SP;
+import org.spinrdf.vocabulary.SP;
 
 @ResourceView
 @HashId

--- a/pom.xml
+++ b/pom.xml
@@ -754,5 +754,10 @@
 				<enabled>false</enabled>
 			</snapshots>
 		</repository>
+
+		<repository>
+			<id>jitpack.io</id>
+			<url>https://jitpack.io</url>
+		</repository>
 	</repositories>
 </project>


### PR DESCRIPTION
Solves #41 by replacing the TopQuadrant maintained (but now apparently discontinued) maven package of SPIN API with the github repo [spinrdf/spinrdf](https://github.com/spinrdf/spinrdf), created by @afs from the TopQuadrant code