### PR TITLE
Always use seqId in logEntryId

### DIFF
--- a/lsq-model/src/main/java/org/aksw/simba/lsq/model/RemoteExecution.java
+++ b/lsq-model/src/main/java/org/aksw/simba/lsq/model/RemoteExecution.java
@@ -29,7 +29,7 @@ public interface RemoteExecution
         // TODO If there is a timestamp then use it
         // Otherwise, use sourceFileName + sequenceId
         String logEntryId = serviceId + "_" + (timestamp != null
-                ? timestamp.toInstant().toString()
+                ? timestamp.toInstant().toString() + "_" + seqId
                 : seqId);
 
         return logEntryId;


### PR DESCRIPTION
This solves issue #40 by always adding seqId at the end of the logEntryId, on which the URI for the corresponding RemoteExecution is based on.
If the timestamp is available, it is still used as part of logEntryId. But now seqId is added after the timestamp, avoiding the clash between different log entries happening in the same time slot.
Note that as the sequence id is computed on the whole input log, it does not restart for each different timestamp.
Another solution would be to use a counter for each different timestamp (restarting thus from 0 or 1), but this could represent a bottleneck during parallel execution.